### PR TITLE
First version

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,95 @@
+{
+    "excludeFiles": [
+        ".git",
+        "node_modules",
+        "./coverage"
+    ],
+    "requireCurlyBraces": [
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "try",
+        "catch"
+    ],
+    "requireSpaceAfterKeywords": [
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "switch",
+        "return",
+        "try",
+        "catch"
+    ],
+    "requireSpaceBeforeBlockStatements": true,
+    "requireParenthesesAroundIIFE": true,
+    "requireSpacesInConditionalExpression": {
+        "beforeConsequent": true,
+        "afterConsequent": true,
+        "beforeAlternate": true
+    },
+    "requireSpacesInConditionalExpression": true,
+    "requireSpacesInFunctionExpression": {
+        "beforeOpeningCurlyBrace": true
+    },
+    "disallowSpacesInFunctionExpression": {
+        "beforeOpeningRoundBrace": true
+    },
+    "requireSpacesInFunctionDeclaration": {
+        "beforeOpeningCurlyBrace": true
+    },
+    "disallowSpacesInFunctionDeclaration": {
+        "beforeOpeningRoundBrace": true
+    },
+    "requireBlocksOnNewline": true,
+    "disallowPaddingNewlinesInBlocks": true,
+    "disallowSpacesInsideObjectBrackets": true,
+    "disallowSpacesInsideArrayBrackets": true,
+    "disallowSpacesInsideParentheses": true,
+    "disallowSpaceAfterObjectKeys": true,
+    "requireCommaBeforeLineBreak": true,
+    "disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~", "!"],
+    "disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],
+    "requireSpaceBeforeBinaryOperators": [
+        "=",
+        "+",
+        "-",
+        "/",
+        "*",
+        "==",
+        "===",
+        "!=",
+        "!=="
+    ],
+
+    "requireSpaceAfterBinaryOperators": [
+        "=",
+        ",",
+        "+",
+        "-",
+        "/",
+        "*",
+        "==",
+        "===",
+        "!=",
+        "!=="
+    ],
+    "requireCamelCaseOrUpperCaseIdentifiers": true,
+    "disallowKeywords": ["with"],
+    "disallowMultipleLineStrings": true,
+    "disallowMultipleLineBreaks": true,
+    "validateLineBreaks": "LF",
+    "validateQuoteMarks": "'",
+    "validateIndentation": 4,
+    "disallowMixedSpacesAndTabs": true,
+    "disallowTrailingWhitespace": true,
+    "disallowTrailingComma": true,
+    "disallowKeywordsOnNewLine": ["else", "catch"],
+    "requireLineFeedAtFileEnd": true,
+    "requireCapitalizedConstructors": true,
+    "safeContextKeyword": ["_this"],
+    "disallowYodaConditions": true
+}

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,2 @@
+node_modules
+/coverage

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,36 @@
+{
+  "bitwise": true,
+  "camelcase": true,
+  "curly": true,
+  "eqeqeq": true,
+  "freeze": true,
+  "immed": true,
+  "indent": 4,
+  "latedef": "nofunc",
+  "newcap": true,
+  "noarg": true,
+  "nonew": true,
+  "quotmark": "single",
+  "undef": true,
+  "unused": "vars",
+  "strict": true,
+  "trailing": true,
+  "maxparams": 3,
+  "node": true,
+  "laxbreak": true,
+  "overrides": {
+    "test/**": {
+      "mocha": true
+    }
+  },
+  "globals": {
+    "describe": false,
+    "before": false,
+    "after": false,
+    "beforeEach": false,
+    "afterEach": false,
+    "it": false,
+    "assert": false,
+    "sinon": false
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+- '4'
+- '0.10'
+script:
+- npm test --coverage
+after_success: cat ${TRAVIS_BUILD_DIR}/coverage/lcov.info | coveralls

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 Hermione-allure-plugin
 ===========
+
+Provides Allure Report for [Hermione Runner](https://github.com/gemini-testing/hermione)
+
+
+##Usage
+
+```
+plugins: {
+    'allure': {
+        targetDir: 'allure-results'
+    }
+}
+```

--- a/index.js
+++ b/index.js
@@ -1,0 +1,67 @@
+'use strict';
+
+var AllureSuite = require('allure-js-commons').Suite,
+    mochaUtils = require('./lib/mocha-utils'),
+    RunningSuites = require('./lib/running-suites'),
+    SuiteAdapter = require('./lib/suite-adapter');
+
+module.exports = function(hermione, opts) {
+    var ALLURE_STATUS = {
+            passed: 'passed',
+            failed: 'failed',
+            pending: 'pending',
+            broken: 'broken'
+        },
+        _runningSuites = new RunningSuites(),
+        targetDir = opts.targetDir ? opts.targetDir : 'allure-results';
+
+    hermione.on(hermione.events.SUITE_BEGIN, function(suite) {
+        if (!mochaUtils.isTopSuite(suite)) {
+            return;
+        }
+
+        if (!_runningSuites.getSuite(suite.title, suite.browserId)) {
+            _runningSuites.addSuite(new AllureSuite(suite.title), suite.browserId);
+        }
+    });
+
+    hermione.on(hermione.events.SUITE_END, function(suite) {
+        if (!mochaUtils.isTopSuite(suite)) {
+            return;
+        }
+        var runningSuite = _runningSuites.getSuite(suite.title, suite.browserId);
+        if (runningSuite) {
+            runningSuite.endSuite(targetDir);
+            _runningSuites.removeSuite(suite.title, suite.browserId);
+        }
+    });
+
+    hermione.on(hermione.events.TEST_BEGIN, function(test) {
+        _runningSuites.startTest(test);
+    });
+
+    hermione.on(hermione.events.TEST_PASS, function _onTestPass(test) {
+        _runningSuites.finishTest(test, ALLURE_STATUS.passed);
+    });
+
+    hermione.on(hermione.events.TEST_FAIL, function(test) {
+        _runningSuites.finishTest(test, ALLURE_STATUS.failed, test.err);
+    });
+
+    hermione.on(hermione.events.TEST_PENDING, function(test) {
+        var runningSuite = _runningSuites.getSuiteByTest(test);
+        runningSuite.addTest(test);
+        runningSuite.finishTest(test, ALLURE_STATUS.pending, {message: 'Test ignored'});
+    });
+
+    hermione.on(hermione.events.ERROR, function(err, data) {
+        if (data && mochaUtils.isBeforeHook(data)) {
+            var suiteAdapter = new SuiteAdapter(new AllureSuite(data.parent.title), data.browserId);
+            mochaUtils.getAllSuiteTests(data.parent).forEach(function(test) {
+                suiteAdapter.addTest(test);
+                suiteAdapter.finishTest(test, ALLURE_STATUS.broken, err);
+            });
+            suiteAdapter.endSuite(targetDir);
+        }
+    });
+};

--- a/lib/mocha-utils.js
+++ b/lib/mocha-utils.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var _ = require('lodash');
+
+module.exports = {
+
+    isBeforeHook: function(mochaEntity) {
+        return mochaEntity.type === 'hook' && /^.?before/.test(mochaEntity.title);
+    },
+
+    isTopSuite: function(mochaEntity) {
+        return mochaEntity.parent && !mochaEntity.parent.parent;
+    },
+
+    getTopSuite: function(mochaEntity) {
+        return this.isTopSuite(mochaEntity) ? mochaEntity : this.getTopSuite(mochaEntity.parent);
+    },
+
+    getTopSuiteTitle: function(mochaEntity) {
+        return this.getTopSuite(mochaEntity).title;
+    },
+
+    /**
+     * Отрезает имя верхнего сьюта от полного имени теста
+     * @param mochaTest
+     */
+    cutTopSuiteTitle: function(mochaTest) {
+        return mochaTest.fullTitle().replace(new RegExp('^' + this.getTopSuiteTitle(mochaTest) + '\\s', 'g'), '');
+    },
+
+    getAllSuiteTests: function(mochaSuite) {
+        return _(mochaSuite.suites)
+            .map(this.getAllSuiteTests.bind(this))
+            .flatten()
+            .concat(mochaSuite.tests)
+            .value();
+    }
+};

--- a/lib/running-suites.js
+++ b/lib/running-suites.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var _ = require('lodash'),
+    inherit = require('inherit'),
+    SuiteAdapter = require('./suite-adapter'),
+    mochaUtils = require('./mocha-utils');
+
+module.exports = inherit({
+    __constructor: function() {
+        this._suites = [];
+    },
+
+    addSuite: function(allureSuite, browser) {
+        this._suites.push(new SuiteAdapter(allureSuite, browser));
+    },
+
+    getSuite: function(title, browser) {
+        return _.find(this._suites, {title: title, browser: browser});
+    },
+
+    getSuiteByTest: function(mochaTest) {
+        return this.getSuite(mochaUtils.getTopSuite(mochaTest).title, mochaTest.browserId);
+    },
+
+    removeSuite: function(title, browser) {
+        _.remove(this._suites, {title: title, browser: browser});
+    },
+
+    removeTest: function(mochaTest) {
+        var suite = this.getSuiteByTest(mochaTest);
+        if (suite) {
+            suite.removeTest(mochaTest);
+        }
+    },
+
+    getTest: function(mochaTest) {
+        var suite = this.getSuiteByTest(mochaTest);
+        if (suite) {
+            return suite.getTest(mochaTest);
+        }
+    },
+
+    startTest: function(mochaTest) {
+        this.removeTest(mochaTest);
+        var suite = this.getSuiteByTest(mochaTest);
+        if (suite) {
+            suite.addTest(mochaTest);
+        }
+    },
+
+    finishTest: function(mochaTest, status, err) {
+        var suite = this.getSuiteByTest(mochaTest);
+        if (suite) {
+            suite.finishTest(mochaTest, status, err);
+        }
+    }
+});

--- a/lib/suite-adapter.js
+++ b/lib/suite-adapter.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var _ = require('lodash'),
+    inherit = require('inherit'),
+    AllureTest = require('allure-js-commons').Test,
+    mochaUtils = require('./mocha-utils'),
+    writer = require('allure-js-commons').writer;
+
+module.exports = inherit({
+    __constructor: function(allureSuite, browser) {
+        this.browser = browser;
+        this.title = allureSuite.name;
+        this._allureSuite = allureSuite;
+        this.runningTests = [];
+    },
+
+    addTest: function(mochaTest) {
+        var allureTest = new AllureTest(mochaUtils.cutTopSuiteTitle(mochaTest));
+        allureTest.addParameter('environment-variable', 'browser', this.browser);
+        allureTest.addParameter('environment-variable', 'sessionId', mochaTest.sessionId);
+        this.runningTests.push(allureTest);
+    },
+
+    getTest: function(mochaTest) {
+        return _.find(this.runningTests, {name: mochaUtils.cutTopSuiteTitle(mochaTest)});
+    },
+
+    removeTest: function(mochaTest) {
+        _.remove(this.runningTests, {name: mochaUtils.cutTopSuiteTitle(mochaTest)});
+    },
+
+    finishTest: function(mochaTest, status, err) {
+        var allureTest = this.getTest(mochaTest);
+        if (!allureTest) {
+            return;
+        }
+        this.removeTest(mochaTest);
+        allureTest.end(status, err);
+        this._allureSuite.addTest(allureTest);
+    },
+
+    endSuite: function(targetDir) {
+        this._allureSuite.end();
+        this._allureSuite.write(writer, targetDir);
+    }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "hermione-allure-reporter",
+  "version": "0.0.0",
+  "description": "Hermione plugin provides functionality of Allure report",
+  "main": "index.js",
+  "scripts": {
+    "lint": "jshint . && jscs .",
+    "test-unit": "istanbul test _mocha -- --recursive test/",
+    "test": "npm run lint && npm run test-unit"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:gemini-testing/hermione-allure-reporter.git"
+  },
+  "keywords": [
+    "hermione",
+    "allure"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "allure-js-commons": "git://github.com/pazone/allure-js-commons.git#7b54fdb",
+    "inherit": "^2.2.3",
+    "lodash": "~3.10.1",
+    "mocha": "2.4.5"
+  },
+  "devDependencies": {
+    "chai": "^3.4.1",
+    "istanbul": "^0.4.1",
+    "jscs": "^2.6.0",
+    "jshint": "^2.8.0",
+    "sinon": "^1.17.2",
+    "sinon-chai": "^2.8.0",
+    "hermione": "^0.5.1"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,371 @@
+'use strict';
+
+var allureReporter = require('../index'),
+    EventEmitter = require('events').EventEmitter,
+    AllureSuite = require('allure-js-commons').Suite,
+    Tree = require('./suite-tree');
+
+describe('Allure reporter', function() {
+    var sandbox = sinon.sandbox.create(),
+        hermione,
+        suites;
+
+    function initHermione_() {
+        hermione = new EventEmitter();
+        hermione.events = require('hermione/lib/constants/runner-events');
+        allureReporter(hermione, {targetDir: 'allure-results'});
+    }
+
+    beforeEach(function() {
+        initHermione_();
+
+        suites = [];
+        sandbox.stub(AllureSuite.prototype, 'write', function() {
+            suites.push(this);
+        });
+    });
+
+    afterEach(function() {
+        sandbox.restore();
+    });
+
+    describe('suite', function() {
+        it('should be saved with one test with correct names', function() {
+            var tree = new Tree()
+                    .suite('topSuite')
+                        .test('someTest')
+                        .end();
+
+            hermione.emit(hermione.events.SUITE_BEGIN, tree.topSuite);
+            hermione.emit(hermione.events.TEST_BEGIN, tree.someTest);
+            hermione.emit(hermione.events.TEST_PASS, tree.someTest);
+            hermione.emit(hermione.events.SUITE_END, tree.topSuite);
+
+            assert.lengthOf(suites, 1);
+            assert.lengthOf(suites[0].testcases, 1);
+            assert.equal(suites[0].name, 'topSuite');
+            assert.equal(suites[0].testcases[0].name, 'someTest');
+            assert.equal(suites[0].testcases[0].status, 'passed');
+        });
+
+        it('should be saved one test with correct names when it fails', function() {
+            var tree = new Tree()
+                    .suite('topSuite')
+                        .test('someTest')
+                        .end();
+
+            hermione.emit(hermione.events.SUITE_BEGIN, tree.topSuite);
+            hermione.emit(hermione.events.TEST_BEGIN, tree.someTest);
+            hermione.emit(hermione.events.TEST_FAIL, tree.someTest);
+            hermione.emit(hermione.events.SUITE_END, tree.topSuite);
+
+            assert.lengthOf(suites, 1);
+            assert.lengthOf(suites[0].testcases, 1);
+            assert.equal(suites[0].name, 'topSuite');
+            assert.equal(suites[0].testcases[0].name, 'someTest');
+            assert.equal(suites[0].testcases[0].status, 'failed');
+        });
+
+        it('should not be duplicated on calling SUITE_BEGIN twice', function() {
+            var tree = new Tree()
+                    .suite('someSuite')
+                    .end();
+
+            hermione.emit(hermione.events.SUITE_BEGIN, tree.someSuite);
+            hermione.emit(hermione.events.SUITE_BEGIN, tree.someSuite);
+            hermione.emit(hermione.events.SUITE_END, tree.someSuite);
+
+            assert.lengthOf(suites, 1);
+        });
+
+        it('should not be duplicated on calling SUITE_END twice', function() {
+            var tree = new Tree()
+                    .suite('someSuite')
+                    .end();
+
+            hermione.emit(hermione.events.SUITE_BEGIN, tree.someSuite);
+            hermione.emit(hermione.events.SUITE_END, tree.someSuite);
+            hermione.emit(hermione.events.SUITE_END, tree.someSuite);
+
+            assert.lengthOf(suites, 1);
+        });
+
+        it('should be ignored if it is not top level suite', function() {
+            var tree = new Tree()
+                    .suite('topSuite')
+                        .suite('middleSuite')
+                        .end()
+                    .end();
+
+            hermione.emit(hermione.events.SUITE_BEGIN, tree.middleSuite);
+            hermione.emit(hermione.events.SUITE_END, tree.middleSuite);
+
+            assert.lengthOf(suites, 0);
+        });
+
+        it('should break all nested tests on ERROR', function() {
+            var tree = new Tree()
+                    .beforeHook('beforeHook')
+                    .suite('topSuite')
+                        .test('someTest')
+                        .test('otherTest')
+                        .end();
+
+            hermione.emit(hermione.events.ERROR, new Error('err'), tree.beforeHook);
+
+            assert.equal(suites[0].testcases[0].status, 'broken');
+            assert.equal(suites[0].testcases[1].status, 'broken');
+        });
+
+        it('should not affect passed suite on ERROR after execution', function() {
+            var tree = new Tree()
+                    .suite('someSuite')
+                        .beforeHook('beforeHook')
+                        .test('someTest')
+                        .end()
+                    .suite('otherSuite')
+                        .suite('middleSuite')
+                            .test('otherTest')
+                            .end()
+                        .end();
+
+            hermione.emit(hermione.events.SUITE_BEGIN, tree.otherSuite);
+            hermione.emit(hermione.events.SUITE_BEGIN, tree.middleSuite);
+            hermione.emit(hermione.events.TEST_BEGIN, tree.otherTest);
+            hermione.emit(hermione.events.TEST_PASS, tree.otherTest);
+            hermione.emit(hermione.events.SUITE_END, tree.middleSuite);
+            hermione.emit(hermione.events.SUITE_END, tree.otherSuite);
+
+            hermione.emit(hermione.events.ERROR, new Error('err'), tree.beforeHook);
+
+            assert.lengthOf(suites, 2);
+
+            assert.equal(suites[1].testcases[0].status, 'broken');
+
+            assert.lengthOf(suites[0].testcases, 1);
+            assert.equal(suites[0].name, 'otherSuite');
+            assert.equal(suites[0].testcases[0].name, 'middleSuite otherTest');
+            assert.equal(suites[0].testcases[0].status, 'passed');
+        });
+
+        it('should not affect passed suite on ERROR during execution', function() {
+            var tree = new Tree()
+                    .suite('someSuite')
+                        .beforeHook('beforeHook')
+                        .test('someTest')
+                        .end()
+                    .suite('otherSuite')
+                        .suite('middleSuite')
+                            .test('otherTest')
+                            .end()
+                        .end();
+
+            hermione.emit(hermione.events.SUITE_BEGIN, tree.otherSuite);
+            hermione.emit(hermione.events.ERROR, new Error('err'), tree.beforeHook);
+            hermione.emit(hermione.events.SUITE_BEGIN, tree.middleSuite);
+            hermione.emit(hermione.events.TEST_BEGIN, tree.otherTest);
+            hermione.emit(hermione.events.TEST_PASS, tree.otherTest);
+            hermione.emit(hermione.events.SUITE_END, tree.middleSuite);
+            hermione.emit(hermione.events.SUITE_END, tree.otherSuite);
+
+            assert.lengthOf(suites, 2);
+
+            assert.equal(suites[0].testcases[0].status, 'broken');
+
+            assert.lengthOf(suites[1].testcases, 1);
+            assert.equal(suites[1].name, 'otherSuite');
+            assert.equal(suites[1].testcases[0].name, 'middleSuite otherTest');
+            assert.equal(suites[1].testcases[0].status, 'passed');
+        });
+    });
+
+    describe('test', function() {
+        it('should be ignored when started without suite', function() {
+            var tree = new Tree()
+                    .suite('someSuite')
+                        .test('someTest')
+                        .end();
+
+            hermione.emit(hermione.events.TEST_BEGIN, tree.someTest);
+            hermione.emit(hermione.events.TEST_PASS, tree.someTest);
+
+            assert.lengthOf(suites, 0);
+        });
+
+        it('should not be attached to wrong suite', function() {
+            var tree = new Tree()
+                    .suite('someSuite')
+                        .test('someTest')
+                        .end()
+                    .suite('otherSuite')
+                    .end();
+
+            hermione.emit(hermione.events.SUITE_BEGIN, tree.otherSuite);
+            hermione.emit(hermione.events.TEST_BEGIN, tree.someTest);
+            hermione.emit(hermione.events.TEST_PASS, tree.someTest);
+            hermione.emit(hermione.events.SUITE_END, tree.otherSuite);
+
+            assert.lengthOf(suites, 1);
+            assert.lengthOf(suites[0].testcases, 0);
+        });
+
+        it('should not be attached to suite with another browser', function() {
+            var firefoxTree = new Tree({browserId: 'firefox'})
+                    .suite('firefox')
+                .end(),
+                chromeTree = new Tree({browserId: 'chrome'})
+                .suite('firefox')
+                    .test('someTest')
+                .end();
+
+            hermione.emit(hermione.events.SUITE_BEGIN, firefoxTree.firefox);
+            hermione.emit(hermione.events.SUITE_BEGIN, chromeTree.firefox);
+            hermione.emit(hermione.events.TEST_BEGIN, chromeTree.someTest);
+            hermione.emit(hermione.events.TEST_PASS, chromeTree.someTest);
+            hermione.emit(hermione.events.SUITE_END, firefoxTree.firefox);
+            hermione.emit(hermione.events.SUITE_END, chromeTree.firefox);
+
+            assert.lengthOf(suites, 2);
+            assert.lengthOf(suites[0].testcases, 0);
+            assert.lengthOf(suites[1].testcases, 1);
+        });
+
+        it('should be attached to suite with proper browser', function() {
+            var firefoxTree = new Tree({browserId: 'firefox'})
+                    .suite('suite')
+                        .test('test')
+                    .end(),
+                chromeTree = new Tree({browserId: 'chrome'})
+                    .suite('suite')
+                        .test('test')
+                    .end();
+
+            hermione.emit(hermione.events.SUITE_BEGIN, firefoxTree.suite);
+            hermione.emit(hermione.events.SUITE_BEGIN, chromeTree.suite);
+            hermione.emit(hermione.events.TEST_BEGIN, chromeTree.test);
+            hermione.emit(hermione.events.TEST_BEGIN, firefoxTree.test);
+            hermione.emit(hermione.events.TEST_PASS, chromeTree.test);
+            hermione.emit(hermione.events.TEST_PASS, firefoxTree.test);
+            hermione.emit(hermione.events.SUITE_END, chromeTree.suite);
+            hermione.emit(hermione.events.SUITE_END, firefoxTree.suite);
+
+            assert.lengthOf(suites, 2);
+            suites.forEach(function(suite) {
+                assert.lengthOf(suite.testcases, 1);
+            });
+        });
+
+        it('should be attached to suite with proper browser with different status', function() {
+            var firefoxTree = new Tree({browserId: 'firefox'})
+                    .suite('suite')
+                    .test('test')
+                    .end(),
+                chromeTree = new Tree({browserId: 'chrome'})
+                    .suite('suite')
+                    .test('test')
+                    .end();
+
+            hermione.emit(hermione.events.SUITE_BEGIN, firefoxTree.suite);
+            hermione.emit(hermione.events.SUITE_BEGIN, chromeTree.suite);
+            hermione.emit(hermione.events.TEST_BEGIN, chromeTree.test);
+            hermione.emit(hermione.events.TEST_BEGIN, firefoxTree.test);
+            hermione.emit(hermione.events.TEST_PASS, chromeTree.test);
+            hermione.emit(hermione.events.TEST_FAIL, firefoxTree.test);
+            hermione.emit(hermione.events.SUITE_END, chromeTree.suite);
+            hermione.emit(hermione.events.SUITE_END, firefoxTree.suite);
+
+            assert.lengthOf(suites, 2);
+            assert.equal(suites[0].testcases[0].status, 'passed');
+            assert.equal(suites[1].testcases[0].status, 'failed');
+        });
+
+        it('should not be attached to finished suite', function() {
+            var tree = new Tree()
+                    .suite('someSuite')
+                        .test('someTest')
+                        .end()
+                    .suite('otherSuite')
+                    .end();
+
+            hermione.emit(hermione.events.SUITE_BEGIN, tree.otherSuite);
+            hermione.emit(hermione.events.TEST_BEGIN, tree.someTest);
+            hermione.emit(hermione.events.SUITE_END, tree.otherSuite);
+            hermione.emit(hermione.events.TEST_PASS, tree.someTest);
+
+            assert.lengthOf(suites, 1);
+            assert.lengthOf(suites[0].testcases, 0);
+        });
+
+        it('should not be duplicated on calling TEST_BEGIN twice for one test', function() {
+            var tree = new Tree()
+                    .suite('someSuite')
+                        .test('someTest')
+                        .end();
+
+            hermione.emit(hermione.events.SUITE_BEGIN, tree.someSuite);
+            hermione.emit(hermione.events.TEST_BEGIN, tree.someTest);
+            hermione.emit(hermione.events.TEST_BEGIN, tree.someTest);
+            hermione.emit(hermione.events.TEST_PASS, tree.someTest);
+            hermione.emit(hermione.events.SUITE_END, tree.someSuite);
+
+            assert.lengthOf(suites, 1);
+            assert.lengthOf(suites[0].testcases, 1);
+            assert.equal(suites[0].testcases[0].name, 'someTest');
+        });
+
+        it('should not be duplicated on calling TEST_PASS twice for one test', function() {
+            var tree = new Tree()
+                    .suite('someSuite')
+                        .test('someTest')
+                        .end();
+
+            hermione.emit(hermione.events.SUITE_BEGIN, tree.someSuite);
+            hermione.emit(hermione.events.TEST_BEGIN, tree.someTest);
+            hermione.emit(hermione.events.TEST_PASS, tree.someTest);
+            hermione.emit(hermione.events.TEST_PASS, tree.someTest);
+            hermione.emit(hermione.events.SUITE_END, tree.someSuite);
+
+            assert.lengthOf(suites, 1);
+            assert.lengthOf(suites[0].testcases, 1);
+            assert.equal(suites[0].testcases[0].name, 'someTest');
+        });
+
+        it('should save whole tree for pending test', function() {
+            var tree = new Tree()
+                    .suite('topSuite')
+                        .suite('middleSuite')
+                            .test('someTest')
+                            .end()
+                        .end();
+
+            hermione.emit(hermione.events.SUITE_BEGIN, tree.topSuite);
+            hermione.emit(hermione.events.TEST_PENDING, tree.someTest);
+            hermione.emit(hermione.events.SUITE_END, tree.topSuite);
+
+            assert.lengthOf(suites, 1);
+            assert.lengthOf(suites[0].testcases, 1);
+            assert.equal(suites[0].name, 'topSuite');
+            assert.equal(suites[0].testcases[0].name, 'middleSuite someTest');
+            assert.equal(suites[0].testcases[0].status, 'pending');
+        });
+    });
+
+    it('should unbend mocha tree structure', function() {
+        var tree = new Tree()
+                .suite('topSuite')
+                    .suite('middleSuite')
+                        .test('someTest')
+                        .end()
+                    .end();
+
+        hermione.emit(hermione.events.SUITE_BEGIN, tree.topSuite);
+        hermione.emit(hermione.events.TEST_BEGIN, tree.someTest);
+        hermione.emit(hermione.events.TEST_PASS, tree.someTest);
+        hermione.emit(hermione.events.SUITE_END, tree.topSuite);
+
+        assert.lengthOf(suites, 1);
+        assert.lengthOf(suites[0].testcases, 1);
+        assert.equal(suites[0].name, 'topSuite');
+        assert.equal(suites[0].testcases[0].name, 'middleSuite someTest');
+    });
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--require ./test/setup

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var chai = require('chai');
+
+global.sinon = require('sinon');
+global.assert = chai.assert;
+
+chai.use(require('sinon-chai'));
+sinon.assert.expose(chai.assert, {prefix: ''});

--- a/test/suite-tree.js
+++ b/test/suite-tree.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var inherit = require('inherit'),
+    _ = require('lodash'),
+    MochaSuite = require('mocha/lib/suite'),
+    MochaTest = require('mocha/lib/test'),
+    MochaHook = require('mocha/lib/hook');
+
+var Suite = inherit({
+    __constructor: function(suiteData) {
+        this._parent = suiteData.parent;
+        this._suite = suiteData.mochaSuite;
+        this.browserId = suiteData.browserId;
+    },
+
+    suite: function(title) {
+        var suite = MochaSuite.create(this._suite, title);
+        this._addChild(title, suite);
+        return new Suite({mochaSuite: suite, parent: this, browserId: this.browserId});
+    },
+
+    test: function(title) {
+        var test = new MochaTest(title, _.noop);
+        this._suite.tests.push(test);
+        return this._addChild(title, test);
+    },
+
+    beforeHook: function(title) {
+        var hook = new MochaHook('before hook', _.noop);
+        return this._addChild(title, hook);
+    },
+
+    _addChild: function(title, child) {
+        child.parent = this._suite;
+        child.browserId = this.browserId;
+        this._push(title, child);
+        return this;
+    },
+
+    end: function() {
+        return this._parent;
+    },
+
+    _push: function(title, obj) {
+        return this._parent._push(title, obj);
+    }
+});
+
+module.exports = inherit(Suite, {
+    __constructor: function(suiteData) {
+        this.browserId = suiteData && suiteData.browserId;
+        this._suite = new MochaSuite('');
+        this._suite.browserId = this.browserId;
+    },
+
+    _push: function(title, obj) {
+        this[title] = obj;
+    },
+
+    end: function() {
+        return this;
+    }
+});


### PR DESCRIPTION
Особенности работы:
`SuiteHolder` - хелпер для асоциирования тестов и съютов в рантайме. Содержит набор запущенных на данный момент сьютов, ассоциированных с тестами.
`SuiteEntry` -  Один запущенный съют, к которому в процессе его работы асоциируются тесты.
- На каждый верхний describe создается объкт `AllureSuite` и записывается в `SuiteHolder`.
- При завершении сьюта AllureSuite сериализуется в файл, который будет лежать в `targetDir`. После сериализации соответствующая `SuiteEntry` удаляется
- Когда стартует тест, ищестся его сьют, учитывая браузер и он с ним ассоциируется в `suiteHolder`. 
- в случае ошибки beforeHook, `ERROR` генерируется до `SUITE_START`. По хуку, в котором произошла ошибка, вычисляем сьюты, на которые он влияет, создаем их, помечаем все их тесты статусом `broken` и сразу записываем сьют.
- при ретраях `SUITE_BEGIN` генерируется повторно. Если это случилось повторно, находим созданный ранее `suiteEntry` и заменяем в нем старый тест на новый, чтобы обновить время старта.
- Дерево mocha-тестов "выпрямляется". Внутрениие describe склеиваются с именем кейса.

@sipayRT @j0tunn 
