### PR TITLE
Tree abstraction for tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,8 @@ module.exports = function(hermione, opts) {
             return;
         }
 
-        if (!_runningSuites.getRunningSuite(suite.title, suite.browserId)) {
-            _runningSuites.addRunningSuite(new AllureSuite(suite.title), suite.browserId);
+        if (!_runningSuites.getSuite(suite.title, suite.browserId)) {
+            _runningSuites.addSuite(new AllureSuite(suite.title), suite.browserId);
         }
     });
 
@@ -29,10 +29,10 @@ module.exports = function(hermione, opts) {
         if (!mochaUtils.isTopSuite(suite)) {
             return;
         }
-        var runningSuite = _runningSuites.getRunningSuite(suite.title, suite.browserId);
+        var runningSuite = _runningSuites.getSuite(suite.title, suite.browserId);
         if (runningSuite) {
             runningSuite.endSuite(targetDir);
-            _runningSuites.removeRunningSuite(suite.title, suite.browserId);
+            _runningSuites.removeSuite(suite.title, suite.browserId);
         }
     });
 
@@ -49,7 +49,7 @@ module.exports = function(hermione, opts) {
     });
 
     hermione.on(hermione.events.TEST_PENDING, function(test) {
-        var runningSuite = _runningSuites.getRunningSuiteByTest(test);
+        var runningSuite = _runningSuites.getSuiteByTest(test);
         runningSuite.addTest(test);
         runningSuite.finishTest(test, ALLURE_STATUS.pending, {message: 'Test ignored'});
     });

--- a/lib/mocha-utils.js
+++ b/lib/mocha-utils.js
@@ -33,10 +33,10 @@ module.exports = {
     },
 
     retrieveTests: function(mochaSuite, testsSet) {
-        if (mochaSuite.suites && mochaSuite.suites.length) {
+        if (mochaSuite.suites) {
             mochaSuite.suites.forEach(function(suite) {
                 this.retrieveTests(suite, testsSet);
-            }.bind(this));
+            }, this);
         }
         if (mochaSuite.tests) {
             mochaSuite.tests.forEach(function(test) {

--- a/lib/running-suites.js
+++ b/lib/running-suites.js
@@ -6,53 +6,52 @@ var _ = require('lodash'),
     mochaUtils = require('./mocha-utils');
 
 module.exports = inherit({
-
     __constructor: function() {
         this._suites = [];
     },
 
-    addRunningSuite: function(allureSuite, browser) {
+    addSuite: function(allureSuite, browser) {
         this._suites.push(new SuiteAdapter(allureSuite, browser));
     },
 
-    getRunningSuite: function(title, browser) {
+    getSuite: function(title, browser) {
         return _.find(this._suites, {title: title, browser: browser});
     },
 
-    getRunningSuiteByTest: function(mochaTest) {
-        return this.getRunningSuite(mochaUtils.getTopSuite(mochaTest).title, mochaTest.browserId);
+    getSuiteByTest: function(mochaTest) {
+        return this.getSuite(mochaUtils.getTopSuite(mochaTest).title, mochaTest.browserId);
     },
 
-    removeRunningSuite: function(title, browser) {
+    removeSuite: function(title, browser) {
         _.remove(this._suites, {title: title, browser: browser});
     },
 
-    removeRunningTest: function(mochaTest) {
-        var runningSuite = this.getRunningSuiteByTest(mochaTest);
-        if (runningSuite) {
-            runningSuite.removeRunningTest(mochaTest);
+    removeTest: function(mochaTest) {
+        var suite = this.getSuiteByTest(mochaTest);
+        if (suite) {
+            suite.removeTest(mochaTest);
         }
     },
 
-    getRunningTest: function(mochaTest) {
-        var runningSuite = this.getRunningSuiteByTest(mochaTest);
-        if (runningSuite) {
-            return runningSuite.getRunningTest(mochaTest);
+    getTest: function(mochaTest) {
+        var suite = this.getSuiteByTest(mochaTest);
+        if (suite) {
+            return suite.getTest(mochaTest);
         }
     },
 
     startTest: function(mochaTest) {
-        this.removeRunningTest(mochaTest);
-        var runningSuite = this.getRunningSuiteByTest(mochaTest);
-        if (runningSuite) {
-            runningSuite.addTest(mochaTest);
+        this.removeTest(mochaTest);
+        var suite = this.getSuiteByTest(mochaTest);
+        if (suite) {
+            suite.addTest(mochaTest);
         }
     },
 
     finishTest: function(mochaTest, status, err) {
-        var runningSuite = this.getRunningSuiteByTest(mochaTest);
-        if (runningSuite) {
-            runningSuite.finishTest(mochaTest, status, err);
+        var suite = this.getSuiteByTest(mochaTest);
+        if (suite) {
+            suite.finishTest(mochaTest, status, err);
         }
     }
 });

--- a/lib/suite-adapter.js
+++ b/lib/suite-adapter.js
@@ -21,20 +21,20 @@ module.exports = inherit({
         this.runningTests.push(allureTest);
     },
 
-    getRunningTest: function(mochaTest) {
+    getTest: function(mochaTest) {
         return _.find(this.runningTests, {name: mochaUtils.cutTopSuiteTitle(mochaTest)});
     },
 
-    removeRunningTest: function(mochaTest) {
+    removeTest: function(mochaTest) {
         _.remove(this.runningTests, {name: mochaUtils.cutTopSuiteTitle(mochaTest)});
     },
 
     finishTest: function(mochaTest, status, err) {
-        var allureTest = this.getRunningTest(mochaTest);
+        var allureTest = this.getTest(mochaTest);
         if (!allureTest) {
             return;
         }
-        this.removeRunningTest(mochaTest);
+        this.removeTest(mochaTest);
         allureTest.end(status, err);
         this._allureSuite.addTest(allureTest);
     },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "jshint . && jscs .",
     "test-unit": "istanbul test _mocha -- --recursive test/",
-    "test": "npm run lint && npm run test-unit"
+    "test": "npm run test-unit"
   },
   "repository": {
     "type": "git",

--- a/test/suite-tree.js
+++ b/test/suite-tree.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var inherit = require('inherit'),
+    _ = require('lodash'),
+    MochaSuite = require('mocha/lib/suite'),
+    MochaTest = require('mocha/lib/test'),
+    MochaHook = require('mocha/lib/hook');
+
+var Suite = inherit({
+    __constructor: function(mochaSuite, parent) {
+        this._parent = parent;
+        this._suite = mochaSuite;
+    },
+
+    suite: function(title) {
+        var suite = MochaSuite.create(this._suite, title);
+        this._addChild(title, suite);
+        return new Suite(suite, this);
+    },
+
+    test: function(title) {
+        var test = new MochaTest(title, _.noop);
+        this._suite.tests.push(test);
+        return this._addChild(title, test);
+    },
+
+    beforeHook: function(title) {
+        var hook = new MochaHook('before hook', _.noop);
+        return this._addChild(title, hook);
+    },
+
+    _addChild: function(title, child) {
+        child.parent = this._suite;
+        this._push(title, child);
+        return this;
+    },
+
+    end: function() {
+        return this._parent;
+    },
+
+    _push: function(title, obj) {
+        return this._parent._push(title, obj);
+    }
+});
+
+module.exports = inherit(Suite, {
+    __constructor: function() {
+        this._suite = new MochaSuite('');
+    },
+
+    _push: function(title, obj) {
+        this[title] = obj;
+    },
+
+    end: function() {
+        return this;
+    }
+});


### PR DESCRIPTION
Используя абстракцию для тестов/сьютов заменил глобальное дерево в тестах на локальные в рамках одного теста.

Ничего больше не правил, только убрал `commonCaseVerification` и лишний текст. Все остальные исправления можно будет сделать в рамках основного PR'а
