### PR TITLE
Fixed expected before all hook position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1 - 2016-03-02
+
+* Improved error handling
+
 ## 1.0.0 - 2016-02-26
 
 * Initial release

--- a/README.md
+++ b/README.md
@@ -13,3 +13,22 @@ plugins: {
     }
 }
 ```
+
+If you've got test file without suites(`it`-only), like
+
+```
+// no describe block
+
+it('test1', functuion() {
+    // ...
+});
+
+it('test2', functuion() {
+    // ...
+});
+
+//the end
+
+```
+
+This test results will look not so pretty like well-formed.

--- a/lib/mocha-utils.js
+++ b/lib/mocha-utils.js
@@ -3,17 +3,16 @@
 var _ = require('lodash');
 
 module.exports = {
-
     isBeforeHook: function(mochaEntity) {
-        return mochaEntity.type === 'hook' && /^.?before/.test(mochaEntity.title);
+        return mochaEntity.type === 'hook' && /^.?before all/.test(mochaEntity.title);
     },
 
-    isTopSuite: function(mochaEntity) {
+    isTopEntity: function(mochaEntity) {
         return mochaEntity.parent && !mochaEntity.parent.parent;
     },
 
     getTopSuite: function(mochaEntity) {
-        return this.isTopSuite(mochaEntity) ? mochaEntity : this.getTopSuite(mochaEntity.parent);
+        return this.isTopEntity(mochaEntity) ? mochaEntity : this.getTopSuite(mochaEntity.parent);
     },
 
     getTopSuiteTitle: function(mochaEntity) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermione-allure-reporter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Hermione plugin provides functionality of Allure report",
   "main": "index.js",
   "scripts": {

--- a/test/suite-tree.js
+++ b/test/suite-tree.js
@@ -26,7 +26,7 @@ var Suite = inherit({
     },
 
     beforeHook: function(title) {
-        var hook = new MochaHook('before hook', _.noop);
+        var hook = new MochaHook('before all hook', _.noop);
         return this._addChild(title, hook);
     },
 


### PR DESCRIPTION
@j0tunn @sipayRT @SwinX 
Неправильно искался корневой сьют, в котором произошла ошибка.
Удалил тест, где `before all` хук бросает ошибку после всех сьютов. Такой сценарий невозможен.
В таком случае репортер ничего не знает об уже выполненных тестах и продублирует выполненные тесты со статусом `error`
