### PR TITLE
Support handling of event 'SUITE_FAIL'

### DIFF
--- a/lib/mocha-utils.js
+++ b/lib/mocha-utils.js
@@ -3,10 +3,6 @@
 var _ = require('lodash');
 
 module.exports = {
-    isBeforeHook: function(mochaEntity) {
-        return mochaEntity.type === 'hook' && /^.?before all/.test(mochaEntity.title);
-    },
-
     isTopEntity: function(mochaEntity) {
         return mochaEntity.parent && !mochaEntity.parent.parent;
     },


### PR DESCRIPTION
/cc @j0tunn  @sipayRT 

Теперь при падении `before all` хука примерно вот такой отчет строится:
1. ![0kakg-2016-07-11_18-26-25](https://cloud.githubusercontent.com/assets/6376693/16736293/095ff528-4795-11e6-8664-35970960a5c4.png)
2. ![4plmd-2016-07-11_18-27-22](https://cloud.githubusercontent.com/assets/6376693/16736326/287dba6c-4795-11e6-8890-e25d92f954a6.png)
3. ![vii8u-2016-07-11_18-28-59](https://cloud.githubusercontent.com/assets/6376693/16736401/6ca77b9c-4795-11e6-8720-204d56cbb80e.png)
4. ![2xwqg-2016-07-11_18-30-29](https://cloud.githubusercontent.com/assets/6376693/16736428/953907b0-4795-11e6-9dc5-becba10491e0.png)
