### PR TITLE
do not close suite if it has pending tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = function(hermione, opts) {
             return;
         }
         var runningSuite = _runningSuites.getSuite(suite.title, suite.browserId);
-        if (runningSuite) {
+        if (runningSuite && runningSuite.runningTests.length === 0) {
             runningSuite.endSuite();
             _runningSuites.removeSuite(suite.title, suite.browserId);
         }


### PR DESCRIPTION
this is workaround for hermione API issue
for some reason hermione sends SUITE_END event all the time then test ends, even if this sute has more running tests
this fix let us keep suite alive till the last test in this suite will be ended